### PR TITLE
MA-2533 Add timeout property to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ zander {
   version "1.2.3"
   buildNumber "100200300"
   releaseNotes "[MA-2136] Bugfix"
-  timeoutSeconds 30
+  connectTimeoutSeconds 30
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ zander {
   version "1.2.3"
   buildNumber "100200300"
   releaseNotes "[MA-2136] Bugfix"
+  timeoutSeconds 30
 }
 ```

--- a/src/main/kotlin/com/publicinmotion/gradle/PublishTask.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/PublishTask.kt
@@ -23,7 +23,7 @@ abstract class PublishTask @Inject constructor(
         url = CreateUrlForVariantUseCase().execute(extension.url, variant),
         authorization = extension.oAuthCredentials,
         globalLogger = logger,
-        timeoutSeconds = extension.timeoutSeconds
+        connectTimeoutSeconds = extension.connectTimeoutSeconds
     )
 
     @TaskAction

--- a/src/main/kotlin/com/publicinmotion/gradle/PublishTask.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/PublishTask.kt
@@ -22,7 +22,8 @@ abstract class PublishTask @Inject constructor(
     private val sendFileUseCase = SendFile(
         url = CreateUrlForVariantUseCase().execute(extension.url, variant),
         authorization = extension.oAuthCredentials,
-        globalLogger = logger
+        globalLogger = logger,
+        timeoutSeconds = extension.timeoutSeconds
     )
 
     @TaskAction

--- a/src/main/kotlin/com/publicinmotion/gradle/SendFile.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/SendFile.kt
@@ -11,7 +11,12 @@ import okhttp3.logging.HttpLoggingInterceptor
 import org.slf4j.Logger
 import java.util.concurrent.TimeUnit
 
-class SendFile(val url: String, val globalLogger: Logger, val authorization: String) {
+class SendFile(
+    val url: String,
+    val globalLogger: Logger,
+    val authorization: String,
+    timeoutSeconds: Long
+) {
 
     private val httpLogger: HttpLoggingInterceptor.Logger = object : HttpLoggingInterceptor.Logger {
         override fun log(message: String) {
@@ -21,9 +26,9 @@ class SendFile(val url: String, val globalLogger: Logger, val authorization: Str
 
     private val client = OkHttpClient()
         .newBuilder()
-        .callTimeout(30, TimeUnit.SECONDS)
-        .writeTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
+        .callTimeout(timeoutSeconds, TimeUnit.SECONDS)
+        .writeTimeout(timeoutSeconds, TimeUnit.SECONDS)
+        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
         .addInterceptor(HttpLoggingInterceptor(httpLogger).apply {
             level = HttpLoggingInterceptor.Level.HEADERS
         })

--- a/src/main/kotlin/com/publicinmotion/gradle/SendFile.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/SendFile.kt
@@ -15,7 +15,7 @@ class SendFile(
     val url: String,
     val globalLogger: Logger,
     val authorization: String,
-    timeoutSeconds: Long
+    connectTimeoutSeconds: Long
 ) {
 
     private val httpLogger: HttpLoggingInterceptor.Logger = object : HttpLoggingInterceptor.Logger {
@@ -26,9 +26,9 @@ class SendFile(
 
     private val client = OkHttpClient()
         .newBuilder()
-        .callTimeout(timeoutSeconds, TimeUnit.SECONDS)
-        .writeTimeout(timeoutSeconds, TimeUnit.SECONDS)
-        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+        .callTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
+        .writeTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
+        .readTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
         .addInterceptor(HttpLoggingInterceptor(httpLogger).apply {
             level = HttpLoggingInterceptor.Level.HEADERS
         })

--- a/src/main/kotlin/com/publicinmotion/gradle/ZanderPluginExtension.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/ZanderPluginExtension.kt
@@ -12,7 +12,7 @@ open class ZanderPluginExtension @Inject constructor(
     var buildNumber: String = ""
     var releaseNotes: String = ""
     var version: String = ""
-    var timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS
+    var connectTimeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS
 
     fun oAuthCredentials(credentials: String) {
         oAuthCredentials = credentials
@@ -34,8 +34,8 @@ open class ZanderPluginExtension @Inject constructor(
         this.version = version
     }
 
-    fun timeoutSeconds(timeoutSeconds: Long) {
-        this.timeoutSeconds = timeoutSeconds
+    fun connectTimeoutSeconds(connectTimeoutSeconds: Long) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds
     }
 
     companion object {

--- a/src/main/kotlin/com/publicinmotion/gradle/ZanderPluginExtension.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/ZanderPluginExtension.kt
@@ -34,6 +34,10 @@ open class ZanderPluginExtension @Inject constructor(
         this.version = version
     }
 
+    fun timeoutSeconds(timeoutSeconds: Long) {
+        this.timeoutSeconds = timeoutSeconds
+    }
+
     companion object {
         private const val DEFAULT_TIMEOUT_SECONDS = 30L
     }

--- a/src/main/kotlin/com/publicinmotion/gradle/ZanderPluginExtension.kt
+++ b/src/main/kotlin/com/publicinmotion/gradle/ZanderPluginExtension.kt
@@ -12,6 +12,7 @@ open class ZanderPluginExtension @Inject constructor(
     var buildNumber: String = ""
     var releaseNotes: String = ""
     var version: String = ""
+    var timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS
 
     fun oAuthCredentials(credentials: String) {
         oAuthCredentials = credentials
@@ -31,5 +32,9 @@ open class ZanderPluginExtension @Inject constructor(
 
     fun version(version: String) {
         this.version = version
+    }
+
+    companion object {
+        private const val DEFAULT_TIMEOUT_SECONDS = 30L
     }
 }

--- a/src/test/kotlin/com/publicinmotion/gradle/NetworkResponseMapperTest.kt
+++ b/src/test/kotlin/com/publicinmotion/gradle/NetworkResponseMapperTest.kt
@@ -41,7 +41,7 @@ class NetworkResponseMapperTest : StringSpec({
             url = baseUrl.toString(),
             authorization = "asd123",
             globalLogger = testLogger,
-            timeoutSeconds = 30
+            connectTimeoutSeconds = 30
         )
 
         val response = sendFile.execute(givenArtifact)
@@ -79,7 +79,7 @@ class NetworkResponseMapperTest : StringSpec({
             url = baseUrl.toString(),
             authorization = "asd123",
             globalLogger = testLogger,
-            timeoutSeconds = 30
+            connectTimeoutSeconds = 30
         )
 
         val response = sendFile.execute(givenArtifact)

--- a/src/test/kotlin/com/publicinmotion/gradle/NetworkResponseMapperTest.kt
+++ b/src/test/kotlin/com/publicinmotion/gradle/NetworkResponseMapperTest.kt
@@ -40,7 +40,8 @@ class NetworkResponseMapperTest : StringSpec({
         val sendFile = SendFile(
             url = baseUrl.toString(),
             authorization = "asd123",
-            globalLogger = testLogger
+            globalLogger = testLogger,
+            timeoutSeconds = 30
         )
 
         val response = sendFile.execute(givenArtifact)
@@ -77,7 +78,8 @@ class NetworkResponseMapperTest : StringSpec({
         val sendFile = SendFile(
             url = baseUrl.toString(),
             authorization = "asd123",
-            globalLogger = testLogger
+            globalLogger = testLogger,
+            timeoutSeconds = 30
         )
 
         val response = sendFile.execute(givenArtifact)

--- a/src/test/kotlin/com/publicinmotion/gradle/SendFileTest.kt
+++ b/src/test/kotlin/com/publicinmotion/gradle/SendFileTest.kt
@@ -11,7 +11,8 @@ class SendFileTest : StringSpec({
         val useCase = SendFile(
             url = "https://zander.domain.com",
             authorization = "asd123",
-            globalLogger = testLogger
+            globalLogger = testLogger,
+            timeoutSeconds = 30
         )
 
         val headers = useCase.execute(givenArtifact).request.headers
@@ -29,7 +30,8 @@ class SendFileTest : StringSpec({
         val useCase = SendFile(
             url = "https://zander.domain.com",
             authorization = "asd123",
-            globalLogger = testLogger
+            globalLogger = testLogger,
+            timeoutSeconds = 30
         )
 
         val request = useCase.execute(givenArtifact).request

--- a/src/test/kotlin/com/publicinmotion/gradle/SendFileTest.kt
+++ b/src/test/kotlin/com/publicinmotion/gradle/SendFileTest.kt
@@ -12,7 +12,7 @@ class SendFileTest : StringSpec({
             url = "https://zander.domain.com",
             authorization = "asd123",
             globalLogger = testLogger,
-            timeoutSeconds = 30
+            connectTimeoutSeconds = 30
         )
 
         val headers = useCase.execute(givenArtifact).request.headers
@@ -31,7 +31,7 @@ class SendFileTest : StringSpec({
             url = "https://zander.domain.com",
             authorization = "asd123",
             globalLogger = testLogger,
-            timeoutSeconds = 30
+            connectTimeoutSeconds = 30
         )
 
         val request = useCase.execute(givenArtifact).request


### PR DESCRIPTION
Debug variant of the customer app with react native bundled has 40 MB. When sending artifacts to Zander 30s timeout was not enough for such a big file.

I made it configurable with a default value of the 30s.